### PR TITLE
Play work sound at the end of the start interval, not rest sound

### DIFF
--- a/lib/background_timer.dart
+++ b/lib/background_timer.dart
@@ -489,13 +489,13 @@ class CountdownState extends State<Countdown> with WidgetsBindingObserver {
 
               /// Switch to the complete state
               status = IntervalStates.complete;
-            } else if (status == IntervalStates.work ||
-                status == IntervalStates.start) {
+            } else if (status == IntervalStates.work) {
               // Play the rest sound
               if (restSoundID != -1) {
                 await pool.play(restSoundID);
               }
-            } else if (status == IntervalStates.rest) {
+            } else if (status == IntervalStates.rest ||
+                status == IntervalStates.start) {
               // Play the work sound
               if (workSoundID != -1) {
                 await pool.play(workSoundID);


### PR DESCRIPTION
Conditional was incorrect and would play the rest sound if the current state was "Start". Fixed so that the proper sound, the work sound, plays when the current state is "Start".